### PR TITLE
FOGL-2213: plugin_reconfigure should treat input argument handle properly

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -92,7 +92,7 @@ Random *random = (Random *)handle;
 void plugin_reconfigure(PLUGIN_HANDLE *handle, string& newConfig)
 {
 ConfigCategory	config("random", newConfig);
-Random		*random = (Random *)handle;
+Random		*random = (Random *)*handle;
 
 	if (config.itemExists("asset"))
 	{


### PR DESCRIPTION
plugin_reconfigure should treat input argument handle as PLUGIN_HANDLE*, not PLUGIN_HANDLE